### PR TITLE
Include regex engines from external libraries

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         toolchain: [ gcc, clang ]
+        engine: [ stl, pcre2, re2, hyperscan ]
         mode: [ debug ]
         include:
           - { os: windows-latest, toolchain: msvc, mode: debug }

--- a/include/glug/detail/backport/type_traits.hpp
+++ b/include/glug/detail/backport/type_traits.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace glug::backport {
+
+template <typename T>
+struct type_identity {
+    using type = T;
+};
+
+template <typename T>
+using type_identity_t = typename type_identity<T>::type;
+
+}  // namespace glug::backport
+

--- a/include/glug/filesystem.hpp
+++ b/include/glug/filesystem.hpp
@@ -1,3 +1,4 @@
+// Provided as part of glug under MIT license, (c) 2025 Dominik Kaszewski
 #pragma once
 
 #include "glug/filter.hpp"

--- a/include/glug/filter.hpp
+++ b/include/glug/filter.hpp
@@ -2,10 +2,10 @@
 #pragma once
 
 #include "glug/glob.hpp"
+#include "glug/regex.hpp"
 
 #include <filesystem>
 #include <iostream>
-#include <regex>
 #include <vector>
 
 namespace glug::glob {
@@ -62,7 +62,7 @@ class filter {
         bool is_negative{};
         bool is_anchored{};
         bool is_directory{};
-        std::regex regex{};
+        regex::engine regex{};
     };
 
     std::vector<ignore_item> items{};

--- a/include/glug/regex.hpp
+++ b/include/glug/regex.hpp
@@ -1,0 +1,26 @@
+// Provided as part of glug under MIT license, (c) 2025 Dominik Kaszewski
+#pragma once
+
+#include <memory>
+#include <string_view>
+
+namespace glug::regex {
+
+namespace detail {
+struct impl;
+}
+
+class engine {
+    public:
+    engine() = default;
+    explicit engine(std::string_view pattern);
+
+    bool match(std::string_view s) const;
+    bool operator()(std::string_view s) const { return match(s); }
+
+    private:
+    std::shared_ptr<detail::impl> pimpl{};
+};
+
+};  // namespace glug::regex
+

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1,3 +1,4 @@
+// Provided as part of glug under MIT license, (c) 2025 Dominik Kaszewski
 #include "glug/filesystem.hpp"
 
 #include <algorithm>

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -58,7 +58,7 @@ filter::filter(
                     glob.is_negative,
                     glob.is_anchored,
                     glob.is_directory,
-                    std::regex{ glob::to_regex(s) },
+                    regex::engine{ glob::to_regex(s) },
                 }
         );
     }
@@ -106,7 +106,7 @@ decision filter::is_ignored(
             const auto& path = item.is_anchored ? full : file;
             return item.is_directory && !entry.is_directory()
                     ? false
-                    : std::regex_match(path.c_str(), item.regex);
+                    : item.regex(path.c_str());
         };
         return make_decision(std::find_if(items.rbegin(), items.rend(), match));
     } else {
@@ -119,7 +119,7 @@ decision filter::is_ignored(
             const auto& path = item.is_anchored ? full : file;
             return item.is_directory && !entry.is_directory()
                     ? false
-                    : std::regex_match(path, item.regex);
+                    : item.regex(path);
         };
         return make_decision(std::find_if(items.rbegin(), items.rend(), match));
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,17 @@
+// Provided as part of glug under MIT license, (c) 2025 Dominik Kaszewski
+#include "glug/filesystem.hpp"
+
+#include <iostream>
+#include <string_view>
+#include <vector>
+
+int main(int argc, const char** argv) {
+    const auto args = std::vector<std::string_view>{ argv, argv + argc };
+    const auto dir = args.size() > 1 ? args[1] : ".";
+    const auto explorer = glug::filesystem::explorer{ dir };
+    for (const auto& file : explorer) {
+        std::cout << file.path().c_str() << "\n";
+    }
+    return 0;
+}
+

--- a/src/regex.cpp
+++ b/src/regex.cpp
@@ -1,0 +1,186 @@
+// Provided as part of glug under MIT license, (c) 2025 Dominik Kaszewski
+#include "glug/regex.hpp"
+
+#include "glug/detail/backport/type_traits.hpp"
+
+#if defined(ENGINE_PCRE2)
+#include <pcre2.h>
+#elif defined(ENGINE_RE2)
+#include <re2/re2.h>
+#elif defined(ENGINE_HYPERSCAN)
+#include <hs/hs.h>
+
+#include <cassert>
+#include <string>
+#else
+#include <regex>
+#endif
+
+namespace glug::regex {
+
+#if defined(ENGINE_PCRE2)
+
+namespace detail {
+
+struct impl {
+    struct code_deleter {
+        void operator()(pcre2_code_8* p) const { pcre2_code_free_8(p); };
+    };
+    struct scratch_deleter {
+        void operator()(pcre2_match_data_8* p) const {
+            pcre2_match_data_free_8(p);
+        };
+    };
+
+    std::unique_ptr<pcre2_code_8, code_deleter> code{};
+    std::unique_ptr<pcre2_match_data_8, scratch_deleter> scratch{};
+};
+
+}  // namespace detail
+
+engine::engine(std::string_view pattern) :
+    pimpl{ std::make_shared<detail::impl>() } {
+
+    auto error_code = int{};
+    auto error_offset = size_t{};
+
+    pimpl->code = {
+        pcre2_compile_8(
+                reinterpret_cast<const unsigned char*>(pattern.data()),
+                pattern.size(),
+                PCRE2_UTF,
+                &error_code,
+                &error_offset,
+                nullptr
+        ),
+        {},
+    };
+    if (!pimpl->code) {
+        pimpl = nullptr;
+        return;
+    }
+
+    pimpl->scratch = {
+        pcre2_match_data_create_from_pattern(pimpl->code.get(), nullptr),
+        {},
+    };
+}
+
+bool engine::match(std::string_view s) const {
+    if (!pimpl) {
+        return false;
+    }
+
+    const auto matches = pcre2_match_8(
+            pimpl->code.get(),
+            reinterpret_cast<const unsigned char*>(s.data()),
+            s.size(),
+            0,
+            PCRE2_ANCHORED | PCRE2_ENDANCHORED,
+            pimpl->scratch.get(),
+            nullptr
+    );
+    return matches >= 0;
+}
+
+#elif defined(ENGINE_RE2)
+
+namespace detail {
+
+struct impl {
+    impl(std::string_view pattern) :
+        regex{ pattern } {}
+
+    re2::RE2 regex;
+};
+
+}  // namespace detail
+
+engine::engine(std::string_view pattern) :
+    pimpl{ std::make_shared<detail::impl>(pattern) } {}
+
+bool engine::match(std::string_view s) const {
+    return pimpl && re2::RE2::FullMatch(s, pimpl->regex);
+}
+
+#elif defined(ENGINE_HYPERSCAN)
+
+namespace detail {
+
+struct impl {
+    struct database_deleter {
+        void operator()(hs_database* p) const { hs_free_database(p); }
+    };
+    struct scratch_deleter {
+        void operator()(hs_scratch* p) const { hs_free_scratch(p); }
+    };
+
+    impl(hs_database* db, hs_scratch* scratch) :
+        db{ db, {} },
+        scratch{ scratch, {} } {}
+
+    std::unique_ptr<hs_database, database_deleter> db{};
+    std::unique_ptr<hs_scratch, scratch_deleter> scratch{};
+};
+
+}  // namespace detail
+
+engine::engine(std::string_view pattern) {
+    // TODO: #15 - backport std::out_ptr
+    auto db = backport::type_identity_t<hs_database*>{};
+    auto error = backport::type_identity_t<hs_compile_error*>{};
+    [[maybe_unused]] auto result = hs_compile(
+            ("^(" + std::string{ pattern } + ")$").c_str(),
+            HS_FLAG_UTF8 | HS_FLAG_SINGLEMATCH,
+            HS_MODE_BLOCK,
+            nullptr,
+            &db,
+            &error
+    );
+    assert(result == HS_SUCCESS);
+
+    auto scratch = backport::type_identity_t<hs_scratch*>{};
+    result = hs_alloc_scratch(db, &scratch);
+    assert(result == HS_SUCCESS);
+    pimpl = std::make_shared<detail::impl>(db, scratch);
+}
+
+bool engine::match(std::string_view s) const {
+    if (!pimpl) {
+        return false;
+    }
+
+    auto found = false;
+    const auto handler = [](auto, auto, auto, auto, void* found) -> int {
+        return *static_cast<bool*>(found) = true;
+    };
+    auto db = pimpl->db.get();
+    auto scratch = pimpl->scratch.get();
+    hs_scan(db, s.data(), s.size(), 0, scratch, handler, &found);
+    return found;
+}
+
+#else
+
+namespace detail {
+
+struct impl {
+    impl(std::string_view s) :
+        re{ s.data(), s.size() } {}
+
+    std::regex re{};
+};
+
+}  // namespace detail
+
+engine::engine(std::string_view pattern) :
+    pimpl{ std::make_shared<detail::impl>(pattern) } {}
+
+bool engine::match(std::string_view s) const {
+    return std::regex_match(s.begin(), s.end(), pimpl->re);
+}
+
+#endif
+
+}  // namespace glug::regex
+

--- a/test/filesystem_explorer_test.cpp
+++ b/test/filesystem_explorer_test.cpp
@@ -1,3 +1,4 @@
+// Provided as part of glug under MIT license, (c) 2025 Dominik Kaszewski
 #include "glug/filesystem.hpp"
 
 #include "test_tree.hpp"

--- a/xmake.lua
+++ b/xmake.lua
@@ -40,10 +40,18 @@ if is_mode('debug') and is_os('linux') then
     end
 end
 
+target('glug')
+    set_kind('binary')
+    add_files('src/**.cpp')
+    add_includedirs('include')
+    add_packages(get_config('engine'))
+    add_options('engine')
+target_end()
+
 target('glug_test')
     set_kind('binary')
     add_tests('default')
-    add_files('src/**.cpp', 'test/**.cpp')
+    add_files('src/**.cpp|main.cpp', 'test/**.cpp')
     add_includedirs('include', 'test')
     add_defines('UNIT_TEST=1')
     add_packages('gtest', get_config('engine'))

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,4 +1,3 @@
--- Provided as part of glug under MIT license, (c) 2025 Dominik Kaszewski
 set_version('3.0.1')
 
 add_rules('mode.release', 'mode.releasedbg', 'mode.debug',  'mode.coverage')
@@ -6,7 +5,28 @@ set_allowedmodes('release', 'releasedbg', 'debug', 'coverage')
 set_languages('c++17')
 set_warnings('all', 'extra', 'pedantic', 'error')
 
+local engines = {
+    re2 = '>= 2025.08.12',
+    pcre2 = '>= 10.44',
+    hyperscan = '>= 5.4.2',
+}
+
+option('engine')
+    set_description('Choose regex engine')
+    set_values('stl', 'pcre2', 're2', 'hyperscan')
+    set_default('stl')
+    set_showmenu(true)
+
+    after_check(function (option)
+        option:add('defines', 'ENGINE_' .. option:value():upper() .. '=1')
+    end)
+option_end()
+
 add_requires('gtest >= 1.16.0')
+if engines[get_config('engine')] then
+    local engine = get_config('engine')
+    add_requires(engine .. ' ' .. engines[engine])
+end
 
 -- https://github.com/xmake-io/xmake/issues/5769
 if is_mode('coverage') then
@@ -26,7 +46,8 @@ target('glug_test')
     add_files('src/**.cpp', 'test/**.cpp')
     add_includedirs('include', 'test')
     add_defines('UNIT_TEST=1')
-    add_packages('gtest')
+    add_packages('gtest', get_config('engine'))
+    add_options('engine')
 target_end()
 
 task('coverage')


### PR DESCRIPTION
Resolves #11 

Vectorscan was considered but omitted due to [packaging issues on non-x86 architectures](https://github.com/xmake-io/xmake-repo/pull/8221) which makes it redundant to hyperscan, while also performing closer to pcre2.

Benchmarks run on Linux Kernel 6.16 source code:

```shell
$ hyperfine --parameter-list engine stl,pcre2,re2,hyperscan --prepare 'xmake config -y --mode=release --engine={engine} && xmake build glug' --warmup 1 'build/linux/x86_64/release/glug ~/code/linux'
```

| Engine | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `stl` | 5.816 ± 0.027 | 5.789 | 5.877 | 2.09 ± 0.02 |
| `pcre2` | 3.793 ± 0.008 | 3.781 | 3.808 | 1.37 ± 0.01 |
| `re2` | 2.806 ± 0.009 | 2.798 | 2.828 | 1.01 ± 0.01 |
| `hyperscan` | 2.776 ± 0.027 | 2.761 | 2.852 | 1.00 |

Absolute numbers don't mean much as they were measured on underpowered hardware, but relative difference shows definite improvement. Running the code under [`valgrind --tool=callgrind`'](https://valgrind.org/docs/manual/cl-manual.html) shows that even on fastest engines >80% of time is spent inside the respective matching functions. This confirms validity of exploring performance improvements like #12 .